### PR TITLE
When the angles of an arc are the same, do nothing.

### DIFF
--- a/lib/prawn_shapes/arc.rb
+++ b/lib/prawn_shapes/arc.rb
@@ -128,7 +128,7 @@ module Prawn
       radius = options[:radius]
       start_degrees = options[:start_angle]
       end_degrees = options[:end_angle]
-      return if start_degrees == end_degrees
+      return [] if start_degrees == end_degrees
 
       overall_start_angle = (start_degrees % 360.0).to_radians
       overall_end_angle = (end_degrees % 360.0).to_radians

--- a/spec/arc_spec.rb
+++ b/spec/arc_spec.rb
@@ -61,6 +61,16 @@ describe 'Graphics#arc_around' do
       curve.coords.length.should > 0
     end
   end
+
+  context 'when the specified angles are the same' do
+    it 'should work' do
+      create_pdf
+      @pdf.arc_around([100, 100], :radius => 50,
+                     :start_angle => 90, :end_angle => 90)
+      curve = PDF::Inspector::Graphics::Curve.analyze(@pdf.render)
+      curve.coords.length.should eq 0
+    end
+  end
 end
 
 describe 'Graphics#half_circle' do


### PR DESCRIPTION
Currently `#arc_vertices` returns `nil` in this situation, but `#open_curve` (and `#closed_curve`) check for emptiness, which blows up for nil.
